### PR TITLE
Skip entity check for _iainternal:player due to it throwing errors

### DIFF
--- a/src/main/java/com/shimincraft/mobarenaitemsadder/MobArenaItemsAdder.java
+++ b/src/main/java/com/shimincraft/mobarenaitemsadder/MobArenaItemsAdder.java
@@ -62,6 +62,10 @@ public final class MobArenaItemsAdder extends JavaPlugin {
     }
 
     private void registerMob(String namespaceID) {
+        if (namespaceID.equals("_iainternal:player")) {
+            getLogger().warning("Skipping _iainternal:player due to registration errors.");
+            return; // Skip this entity
+        }
         String creatureKey = ItemsAdderCreature.getCreatureKey(namespaceID);
         ItemsAdderCreature creature = new ItemsAdderCreature(getEntityType(namespaceID), creatureKey);
         if (creature.isLivingEntity()) {


### PR DESCRIPTION
Probably not the best way to handle this, but it gets rid of the error in console on startup/reloading IA.
